### PR TITLE
Improve support for expansion with * 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Property matching now supports '*' both in the start and in the end of the value
+  [ericof]
 
 
 2.0.0 (2021-07-21)

--- a/src/pas/plugins/memberpropertytogroup/plugin.py
+++ b/src/pas/plugins/memberpropertytogroup/plugin.py
@@ -19,6 +19,7 @@ from zope.component import queryUtility
 from zope.interface import implementer
 
 import logging
+import re
 import os
 
 
@@ -132,10 +133,16 @@ class MPTGPlugin(BasePlugin):
         """check a given group property of a user against a group matcher"""
         if not isinstance(group_prop, str):
             return False
-        star = group_match.endswith("*")
-        if star:
+        start = "^"
+        end = "$"
+        if group_match.startswith("*"):
+            start = ""
+            group_match = group_match[1:]
+        if group_match.endswith("*"):
+            end = ""
             group_match = group_match[:-1]
-        return star and group_prop.startswith(group_match) or group_prop == group_match
+        pattern = f"{start}{group_match}{end}"
+        return True if re.match(pattern, group_prop) else False
 
     # ##
     # pas_interfaces.IGroupsPlugin

--- a/src/pas/plugins/memberpropertytogroup/tests/test_plugin.py
+++ b/src/pas/plugins/memberpropertytogroup/tests/test_plugin.py
@@ -72,6 +72,10 @@ class TestPluginHelpers(unittest.TestCase):
             ("foo", "foo"),
             ("foobar", "foo*"),
             ("foo", "foo*"),
+            ("foo", "*foo*"),
+            ("foo", "*foo"),
+            ("foa", "*fo[ao]"),
+            ("foab", "*fo[ao]*"),
         ]
         for prop, match in TESTS_EQUAL:
             self.assertTrue(


### PR DESCRIPTION
Add support for expansion with * both in the start and in the end of an expression.